### PR TITLE
Fix spec

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -42,7 +42,7 @@ resources:
     access_key_id: {{s3-bosh-releases-access-key-id}}
     secret_access_key: {{s3-bosh-releases-secret-access-key}}
     region_name: {{s3-bosh-releases-region}}
-    server_side_encrytion: AES256
+    server_side_encryption: AES256
 - name: final-builds-dir-tarball
   type: s3
   source:
@@ -51,7 +51,7 @@ resources:
     access_key_id: {{s3-bosh-releases-access-key-id}}
     secret_access_key: {{s3-bosh-releases-secret-access-key}}
     region_name: {{s3-bosh-releases-region}}
-    server_side_encrytion: AES256
+    server_side_encryption: AES256
 - name: releases-dir-tarball
   type: s3
   source:
@@ -60,4 +60,4 @@ resources:
     access_key_id: {{s3-bosh-releases-access-key-id}}
     secret_access_key: {{s3-bosh-releases-secret-access-key}}
     region_name: {{s3-bosh-releases-region}}
-    server_side_encrytion: AES256
+    server_side_encryption: AES256

--- a/jobs/harden/spec
+++ b/jobs/harden/spec
@@ -4,5 +4,4 @@ templates:
   .placeholder: .placeholder
 packages:
 - harden
-properties:
-  foo: bar
+properties: {}


### PR DESCRIPTION
* Use valid empty properties in spec (required by bosh cli v2)
* Spell "encryption" with a p