### PR TITLE
Fix startup from fatal early exit

### DIFF
--- a/src/harden/bin/start.sh
+++ b/src/harden/bin/start.sh
@@ -69,7 +69,10 @@ if [ -d /proc/sys/net/ipv6 ]; then
 fi
 
 # reload all sysctl settings
+# error handling is disabled, ipv6 settings will auto apply if enabled
+set +e
 /sbin/sysctl -p /etc/sysctl.conf
+set -e
 
 
 ###

--- a/src/harden/files/etc/security/limits.conf
+++ b/src/harden/files/etc/security/limits.conf
@@ -1,1 +1,2 @@
 * hard core 0
+vcap hard nofile 65535


### PR DESCRIPTION
* Startup script did not complete because ipv6 is disabled
* Allowing to continue with errors will apply hardening to ipv6 when it is eventually enabled
* Add a hard limit of 65535 to vcap for number of open files.  This will allow jobs to configure their file limits higher if required