### PR TITLE
Better script running

### DIFF
--- a/jobs/harden/monit
+++ b/jobs/harden/monit
@@ -1,2 +1,0 @@
-check file hardening.log with path /tmp/hardening.log
-  if not exist then exec "/bin/bash -c '/var/vcap/packages/harden/bin/start.sh 1> /tmp/hardening-temp.log 2>&1 && mv /tmp/hardening-temp.log /tmp/hardening.log'"

--- a/jobs/harden/spec
+++ b/jobs/harden/spec
@@ -2,6 +2,7 @@
 name: harden
 templates:
   .placeholder: .placeholder
+  bin/post-deploy: bin/post-deploy
 packages:
 - harden
 properties: {}

--- a/jobs/harden/templates/bin/post-deploy
+++ b/jobs/harden/templates/bin/post-deploy
@@ -1,0 +1,2 @@
+#!/bin/bash
+/var/vcap/packages/harden/bin/start.sh 1> /tmp/hardening-temp.log 2>&1

--- a/src/harden/bin/start.sh
+++ b/src/harden/bin/start.sh
@@ -126,7 +126,7 @@ cp etc/pam.d/common-password /etc/pam.d/common-password
 cp etc/pam.d/login /etc/pam.d/login
 cp etc/pam.d/su /etc/pam.d/su
 cp etc/login.defs /etc/login.defs
-cp etc/security/pwquality.conf
+cp etc/security/pwquality.conf /etc/security/pwquality.conf
 
 chown root:root /etc/pam.d/common-password /etc/pam.d/login /etc/login.defs /etc/security/pwquality.conf
 chmod 0644 /etc/pam.d/common-password /etc/pam.d/login /etc/login.defs /etc/security/pwquality.conf


### PR DESCRIPTION
This runs the hardening script as a post-deploy script.

also, this fixes a dumb mistake where I missed the destination on a copy command

# security considerations
- this does mean that the hardening is not running until after our jobs start
- it also means that we're actually picking up changes