### PR TITLE
only try to link grep if it does not already exist

### DIFF
--- a/src/harden/bin/start.sh
+++ b/src/harden/bin/start.sh
@@ -4,7 +4,7 @@ set -e
 echo "---> Starting hardening process"
 
 # cheap hack - nessus for some reason assumes the whole
-ln -s /bin/grep /usr/bin/grep
+[[ -e /usr/bin/grep ]] || ln -s /bin/grep /usr/bin/grep
 
 cd /var/vcap/packages/harden/files
 

--- a/src/harden/bin/start.sh
+++ b/src/harden/bin/start.sh
@@ -3,7 +3,8 @@ set -e
 
 echo "---> Starting hardening process"
 
-# cheap hack - nessus for some reason assumes the whole
+# cheap hack - nessus for some reason assumes it knows the absolute path
+# check first to make sure grep doesn't exist
 [[ -e /usr/bin/grep ]] || ln -s /bin/grep /usr/bin/grep
 
 cd /var/vcap/packages/harden/files


### PR DESCRIPTION
this prevents the start script from failing because grep has already been symlinked

# security considerations
None