### PR TITLE
disable rsync

### DIFF
--- a/jobs/harden/templates/bin/post-deploy
+++ b/jobs/harden/templates/bin/post-deploy
@@ -201,6 +201,12 @@ service rpcbind stop || true
 set -e
 
 ###
+# disable rsync
+###
+
+systemctl disable rsync
+
+###
 # Limit logfile access
 ###
 chmod -R 0600 /var/log/*


### PR DESCRIPTION
This is no biggie, because rsync isn't _acutally_ running anyway - it
has a conditional start (/etc/rsync.conf needs to exist) and we fail
this condition. This is just more explicit for Nessus' sake

## Changes proposed in this pull request:
- disable rsync
-
-

## security considerations
Reduces false-positives from compliance scanning, making real positives easier to spot