### PR TITLE
Jammy fips main

### DIFF
--- a/jobs/ubuntu-advantage-pro-token/templates/drain.sh
+++ b/jobs/ubuntu-advantage-pro-token/templates/drain.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 echo "Detaching Pro License"
-its_ok="`pro detach` failed. This likely means the machine was already detached from a license token."
+its_ok="pro detach failed. This likely means the machine was already detached from a license token."
 pro detach --assume-yes || echo "$its_ok"

--- a/jobs/ubuntu-advantage-pro-token/templates/drain.sh
+++ b/jobs/ubuntu-advantage-pro-token/templates/drain.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 echo "Detaching Pro License"
-pro detach --assume-yes || echo "`pro detach` failed. This is probably ok."
+its_ok="`pro detach` failed. This likely means the machine was already detached from a license token."
+pro detach --assume-yes || echo "$its_ok"

--- a/jobs/ubuntu-advantage-pro-token/templates/drain.sh
+++ b/jobs/ubuntu-advantage-pro-token/templates/drain.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 echo "Detaching Pro License"
-pro detach --assume-yes
+pro detach --assume-yes || echo "`pro detach` failed. This is probably ok."

--- a/jobs/ubuntu-advantage-pro-token/templates/pre-start.sh
+++ b/jobs/ubuntu-advantage-pro-token/templates/pre-start.sh
@@ -2,7 +2,7 @@
 set -ex
 
 echo "Attaching Pro License"
-its_ok="`pro attach` failed. This likely means the machine was already attached to a license token."
+its_ok="pro attach failed. This likely means the machine was already attached to a license token."
 pro attach '<%= p("ubuntu_advantage_pro_token") %>' || echo "$its_ok"
 
 echo "Checking if fips enabled"

--- a/jobs/ubuntu-advantage-pro-token/templates/pre-start.sh
+++ b/jobs/ubuntu-advantage-pro-token/templates/pre-start.sh
@@ -2,7 +2,7 @@
 set -ex
 
 echo "Attaching Pro License"
-pro attach '<%= p("ubuntu_advantage_pro_token") %>'
+pro attach '<%= p("ubuntu_advantage_pro_token") %>' || echo "`pro attach` failed. This might be ok."
 
 echo "Checking if fips enabled"
 current_kernel_fips=$(uname -r | grep "fips")

--- a/jobs/ubuntu-advantage-pro-token/templates/pre-start.sh
+++ b/jobs/ubuntu-advantage-pro-token/templates/pre-start.sh
@@ -2,7 +2,8 @@
 set -ex
 
 echo "Attaching Pro License"
-pro attach '<%= p("ubuntu_advantage_pro_token") %>' || echo "`pro attach` failed. This might be ok."
+its_ok="`pro attach` failed. This likely means the machine was already attached to a license token."
+pro attach '<%= p("ubuntu_advantage_pro_token") %>' || echo "$its_ok"
 
 echo "Checking if fips enabled"
 current_kernel_fips=$(uname -r | grep "fips")


### PR DESCRIPTION
## Changes proposed in this pull request:

- allow `pro` commands to fail. This is usually ok as the license was in the correct state when the command was run. 
- The pre-start script ensures fips modules are loaded regardless of the state of the `pro attach` command. 

The alternative would require installing jq and checking status before running the commands. 

## security considerations

None. License manipulation only. Fips modules are still verified. 
