### PR TITLE
bosh requires an integer denoting sleep time at the end of a drain

### DIFF
--- a/jobs/ubuntu-advantage-pro-token/templates/drain.sh
+++ b/jobs/ubuntu-advantage-pro-token/templates/drain.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+
+set -eo pipefail
+
+exec 3>&1
+exec 1>> /var/vcap/sys/log/ubuntu-advantage-pro-token/drain.stdout.log
+exec 2>> /var/vcap/sys/log/ubuntu-advantage-pro-token/drain.stderr.log
+
 echo "Detaching Pro License"
 its_ok="pro detach failed. This likely means the machine was already detached from a license token."
 pro detach --assume-yes || echo "$its_ok"
+
+echo 0 >&3


### PR DESCRIPTION
## Changes proposed in this pull request:

- Bosh requires an integer on stdout denoting the time to sleep before continuing, otherwise bosh is grumpy. 

## security considerations

None
